### PR TITLE
New regex check

### DIFF
--- a/profcomff_parse_lib/timetable/core/parse_group.py
+++ b/profcomff_parse_lib/timetable/core/parse_group.py
@@ -43,7 +43,15 @@ def _parse_group(group):
         if not (result is None):
             if group == result[0]:
                 return [(result[2 * _i + 1], result[2 * _i + 1 + 1]) for _i in range(i + 1)]
-
+                
+    # xxx-.../xxx -..., короче пробелы не там стоят 
+    result = re.match(rf"({number_group}(?: *м)?) *-.*", group)
+    if not (result is None):
+        if group == result[0]:
+            # извлекаем все номера из всей строки
+            numbers = re.findall(rf"({number_group}(?: *м)?) *-", group)
+            return [(num, "") for num in numbers]
+    
     _logger.warning(f"Для '{group}' не найдено подходящее регулярное выражение.")
     return [(group, "")]
 


### PR DESCRIPTION
Добавил регулярку для корявых названий групп (привет нанофотоника). Проверялось на: 1) 428-каф. нанофотоники (фотоника и физика мкироволн/437 - каф. нанофотоники 2) 528-каф.нанофотоники (фотоника и физика микроволн) 3) 228м -каф.нанофотоники (фотоника и физика микроволн) 4) 309-каф.физ.элементарных частиц/312-каф.физики атомн.ядра и квант. теории столкновений/

## Изменения
<!-- Опишите здесь на языке, понятном каждому, изменения, сделанные в исходном коде по пунктам. -->

## Детали реализации
<!-- Здесь можно описать технические детали по пунктам. -->

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
